### PR TITLE
fix: Revert to Internet Archive URLs

### DIFF
--- a/tools/common.py
+++ b/tools/common.py
@@ -169,12 +169,10 @@ class InternetArchiveSource(object):
             def resolve_root_reference_item(reference_item):
                 return model.ReferenceItem(name=reference_item.name, url=self.url)
 
+            # TODO: Not all first-level containers (e.g., .bin) can be accessed on the Internet Archive.
             def resolve_first_tier_reference_item(reference_item):
-                # Only .iso, .tar, and .zip files are extracted for us on Solarcene.
-                if not self.relative_path.lower()[-4:] in [".iso", ".zip", ".tar"]:
-                    return reference_item
                 return model.ReferenceItem(name=reference_item.name,
-                                           url=f"https://psion.solarcene.community/{self.id}/contents/{reference_item.name}")
+                                           url=self.url + "/" + quote_plus(reference_item.name))
 
             if len(reference) < 1:
                 return reference


### PR DESCRIPTION
This change reverts "fix: Use solarcene mirror for downloads (#82)" (af84e00ee48b616c8a4ec2ab26e983f1b99f85e2) now that the Internet Archive seems more stable again. In the future we should self-host the binaries to avoid a secondary dependency.