### PR TITLE
fix: Format version numbers correctly

### DIFF
--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -33,6 +33,8 @@ class ExtractionTests(unittest.TestCase):
                                          error_handler=error_handler)
         installer_dictionary = installer.as_dict(relative_icons_path="icons")
         self.assertEqual(installer_dictionary["version"], "1.06")
+        self.assertEqual(installer_dictionary["version_components"]["major"], 1)
+        self.assertEqual(installer_dictionary["version_components"]["minor"], 6)
 
 
 if __name__ == "__main__":

--- a/tools/indexer.py
+++ b/tools/indexer.py
@@ -58,7 +58,7 @@ verbose = '--verbose' in sys.argv[1:] or '-v' in sys.argv[1:]
 logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO, format="[%(levelname)s] %(message)s")
 
 
-INDEXER_VERSION = 3
+INDEXER_VERSION = 4
 
 # TODO: Check if there are more languages.
 LANGUAGE_ORDER = ["en_GB", "en_US", "en_AU", "fr_FR", "de_DE", "it_IT", "nl_NL", "bg_BG", ""]

--- a/tools/opolua.py
+++ b/tools/opolua.py
@@ -114,7 +114,15 @@ def run_json_command(command, path):
 
 
 def dumpsis(path):
-    return run_json_command(DUMPSIS_PATH, path)
+    sis = run_json_command(DUMPSIS_PATH, path)
+
+    # Fix-up the version to match the previous expectations.
+    if "version" in sis:
+        version = sis["version"]
+        sis["version"] = "%d.%02d" % (version["major"], version["minor"])
+        sis["version_components"] = version
+
+    return sis
 
 
 def dumpaif(path):
@@ -122,24 +130,9 @@ def dumpaif(path):
 
 
 def dumpsis_extract(source, destination):
-    result = subprocess.run([LUA_PATH, DUMPSIS_PATH, source, destination], capture_output=True)
-
-    # Sadly we ignore foreign characters right now and using CP1252 by default.
-    stdout = result.stdout.decode('utf-8')
-    stderr = result.stderr.decode('utf-8')
-
-    if "Illegal byte sequence" in stdout + stderr:
-        return None
-
-    # Check the return code.
-    try:
-        result.check_returncode()
-    except:
-        print("stderr")
-        print(stderr)
-        print("stdout")
-        print(stdout)
-        raise
+    # TODO: #147: Capture dumpsis stdout and stderr in the case of failures
+    #       https://github.com/inseven/psion-software-index/issues/147
+    subprocess.check_call([LUA_PATH, DUMPSIS_PATH, source, destination])
 
 
 def get_icons(aif_path):


### PR DESCRIPTION
This catches up to the latest version of OpoLua which separates version numbers out into major and minor components making it possible to format them correctly.