### PR TITLE
fix: Include a source kind enum in the sources API

### DIFF
--- a/schema/sources.schema.json
+++ b/schema/sources.schema.json
@@ -7,13 +7,13 @@
     "items": {
         "type": "object",
         "properties": {
+            "kind": {"enum": ["snapshot", "internet-archive"]},
             "name": {"type": "string"},
             "description": {"type": "string"},
-            "path": {"type": "string"},
             "url": {"type": "string"},
             "html_url": {"type": "string"}
         },
-        "required": ["name", "html_url"],
+        "required": ["kind", "name", "html_url"],
         "additionalProperties": false
     }
 }

--- a/tools/common.py
+++ b/tools/common.py
@@ -202,7 +202,7 @@ class InternetArchiveSource(object):
 
     def as_dict(self):
         return {
-            'path': self.path,
+            'kind': 'internet-archive',
             'name': self.title,
             'description': self.description,
             'url': self.url,
@@ -283,6 +283,7 @@ class SnapshotSource(object):
 
     def as_dict(self):
         return {
+            "kind": "snapshot",
             "name": self.title,
             "html_url": self.snapshot_url,
         }


### PR DESCRIPTION
It should be possible to use this to group sources into distinct kinds in the UI.