### PR TITLE
fix: Simplify the site navigation

### DIFF
--- a/site/_includes/navigation.html
+++ b/site/_includes/navigation.html
@@ -1,7 +1,6 @@
 <nav>
     <ul>
         <li>{% include link.html url="/" title="Library" %}</li>
-        <li>{% include link.html url="/index/" title="A-Z" %}</li>
         <li>{% include link.html url="/about/" title="About" %}</li>
         <li>{% include link.html url="/contributing/" title="Contributing" %}</li>
         <li>{% include link.html url="/api/" title="API" %}</li>


### PR DESCRIPTION
This change removes the 'A-Z' entry from the top-level navigation. It will return in a nested information page somewhere.