### PR TITLE
fix: Support multiple links in the overlay metadata

### DIFF
--- a/overlays/0x100053f0 NEUON PacMan/index.md
+++ b/overlays/0x100053f0 NEUON PacMan/index.md
@@ -5,7 +5,8 @@ publishers:
 - Neuon
 authors:
 - Jérôme Dern
-developer_url: https://neuon.com
+links:
+- https://neuon.com
 ---
 
 Published by Neuon, PacMan is a clone of the arcade game. It's let down a little by EPOC’s redraw and animation speed, and the difficulty ramps quite unexpectedly.

--- a/schema/overlay-metadata.schema.json
+++ b/schema/overlay-metadata.schema.json
@@ -48,7 +48,10 @@
             "type": "array",
             "items": {"type": "string"}
         },
-        "developer_url": {"type": "string"}
+        "links": {
+            "type": "array",
+            "items": {"type": "string"}
+        }
     },
     "required": ["subtitle"],
     "additionalProperties": false

--- a/schema/programs.schema.json
+++ b/schema/programs.schema.json
@@ -165,7 +165,10 @@
                 "items": {"type": "string"}
             },
             "description": {"type": "string"},
-            "developer_url": {"type": "string"}
+            "links": {
+                "type": "array",
+                "items": {"type": "string"}
+            }
         },
         "required": ["uid", "name", "tags", "kinds"],
         "additionalProperties": false

--- a/site/_layouts/program.html
+++ b/site/_layouts/program.html
@@ -40,7 +40,7 @@ layout: default
     </div>
 {% endif %}
 
-{% if program.authors or program.publishers or program.developer_url %}
+{% if program.authors or program.publishers or program.links %}
 
 <h2>Information</h2>
 
@@ -62,10 +62,12 @@ layout: default
 </ul>
 {% endif %}
 
-{% if program.developer_url %}
+{% if program.links %}
 <h3>Links</h3>
 <ul>
-    <li><a href="{{ program.developer_url }}">Developer Website</a></li>
+{% for url in program.links %}
+    <li><a href="{{ url }}">{{ url }}</a></li>
+{% endfor %}
 </ul>
 {% endif %}
 

--- a/tools/indexer.py
+++ b/tools/indexer.py
@@ -675,6 +675,10 @@ def overlay(library):
         overlay_schema = json.load(fh)
 
     # Import screenshots and metadata from the overlay.
+    def is_screenshot(path):
+        _, ext = os.path.splitext(path)
+        return ext in [".png", ".gif"]
+    
     overlay = collections.defaultdict(dict)
     for overlay_directory in library.overlay_directories:
         for overlay_basename in utils.listdir(overlay_directory, include_hidden=False):
@@ -682,7 +686,7 @@ def overlay(library):
             screenshots_path = os.path.join(overlay_directory, overlay_basename)
             overlay[identifier]["screenshots"] = [os.path.join(screenshots_path, screenshot)
                                                   for screenshot in os.listdir(screenshots_path)
-                                                  if screenshot.endswith(".png")]
+                                                  if is_screenshot(screenshot)]
             overlay_index_path = os.path.join(overlay_directory, overlay_basename, "index.md")
             if os.path.exists(overlay_index_path):
                 overlay_index = frontmatter.load(overlay_index_path)


### PR DESCRIPTION
This change replaces the single-string metadata property `developer_url` with a new `links` property which accepts and array of URLs. It also includes a drive-by fix to use GIFs as screenshots in addition to PNG files.