### PR TITLE
fix: Improve discovery of EPOC16-era apps

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@
 *.[Gg][Ii][Ff] filter=lfs diff=lfs merge=lfs -text
 *.[Ss][Ii][Ss] filter=lfs diff=lfs merge=lfs -text
 *.[Zz][Ii][Pp] filter=lfs diff=lfs merge=lfs -text
+*.[Oo][Pp][Aa] filter=lfs diff=lfs merge=lfs -text

--- a/examples/EMAILIT.OPA
+++ b/examples/EMAILIT.OPA
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21ce4b6bf58db9b616f02792d18cc0fff854bca02fec0cc69faf7f9234ad03eb
+size 45069

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -110,6 +110,40 @@ class ExtractionTests(unittest.TestCase):
                 }
             ])
 
+    def test_opa_resources(self):
+        release, errors = self._import_application(os.path.join(EXAMPLES_DIRECTORY, "EMAILIT.OPA"))
+        self.assertEqual(len(errors), 0)
+        self.assertIsNotNone(release)
+        self.assertEqual(
+            release,
+            {
+                'filename': 'EMAILIT.OPA',
+                'size': 45069,
+                'reference': [],
+                'kind': 'standalone',
+                'sha256': '21ce4b6bf58db9b616f02792d18cc0fff854bca02fec0cc69faf7f9234ad03eb',
+                'uid': '21ce4b6bf58db9b616f02792d18cc0fff854bca02fec0cc69faf7f9234ad03eb',
+                'name':
+                'eMailIt',
+                'tags': ['opl', 'sibo', 'sis'],
+                'icons': [
+                    {
+                        'filename': 'd6536c02d9edaa8d23eb0d7da9d35c609bf8d1abd0802e0b6425cee7ef9ce56c.gif',
+                        'width': 48,
+                        'height': 48,
+                        'bpp': 1,
+                        'sha256': 'd6536c02d9edaa8d23eb0d7da9d35c609bf8d1abd0802e0b6425cee7ef9ce56c'
+                    },
+                    {
+                        'filename': '7dc76ade97a747bb5520f7b18610920fcf1ad309a63d97bc63aa4dcfd1ee5871.gif',
+                        'width': 48,
+                        'height': 48,
+                        'bpp': 1,
+                        'sha256': '7dc76ade97a747bb5520f7b18610920fcf1ad309a63d97bc63aa4dcfd1ee5871'
+                    }
+                ]
+            })
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -113,7 +113,6 @@ class ExtractionTests(unittest.TestCase):
     def test_opa_resources(self):
         release, errors = self._import_application(os.path.join(EXAMPLES_DIRECTORY, "EMAILIT.OPA"))
         self.assertEqual(len(errors), 0)
-        self.assertIsNotNone(release)
         self.assertEqual(
             release,
             {

--- a/tools/indexer.py
+++ b/tools/indexer.py
@@ -59,7 +59,7 @@ verbose = '--verbose' in sys.argv[1:] or '-v' in sys.argv[1:]
 logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO, format="[%(levelname)s] %(message)s")
 
 
-INDEXER_VERSION = 9
+INDEXER_VERSION = 10
 
 # TODO: Check if there are more languages.
 LANGUAGE_ORDER = ["en_GB", "en_US", "en_AU", "fr_FR", "de_DE", "it_IT", "nl_NL", "bg_BG", ""]


### PR DESCRIPTION
Resource file extraction from OPA apps was failing silently causing us to drop many EPOC16-era apps on the floor. This change addresses that and adds a unit test to catch regressions.

Thanks to @tomsci for all the OpoLua work and fixes.