### PR TITLE
fix: Provide per-platform breakdown statistics

### DIFF
--- a/schema/summary.schema.json
+++ b/schema/summary.schema.json
@@ -20,6 +20,20 @@
         "shaCount": {
             "type": "integer",
             "example": 8546
+        },
+        "platforms": {
+            "type": "object",
+            "properties": {
+                "epoc32": {
+                    "type": "integer",
+                    "example": 6482
+                },
+                "epoc16": {
+                    "type": "integer",
+                    "example": 4552
+                }
+            },
+            "additionalProperties": false
         }
     },
     "required": ["installerCount", "uidCount", "versionCount", "shaCount"],

--- a/site/about/index.md
+++ b/site/about/index.md
@@ -37,6 +37,14 @@ The index is created by extracting metadata from Psion programs that have been p
         <td>Unique files</td>
     </tr>
     <tr>
+        <td class="stat">{{ site.data.summary.platforms.epoc16 }}</td>
+        <td>EPOC16 files</td>
+    </tr>
+    <tr>
+        <td class="stat">{{ site.data.summary.platforms.epoc32 }}</td>
+        <td>EPOC32 files</td>
+    </tr>
+    <tr>
         <td class="stat">{{ site.data.sources.size }}</td>
         <td>Sources</td>
     </tr>

--- a/site/contributing/index.markdown
+++ b/site/contributing/index.markdown
@@ -102,7 +102,7 @@ Supported metadata fields are as follows:
   - `desktop/other`
 - `publishers` - array of strings
 - `authors` - array of strings
-- `developer_url` - string
+- `links` - array of urls
 
 All fields are optional.
 

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -27,6 +27,8 @@ def example_zip(path):
 
 class ExtractionTests(unittest.TestCase):
 
+    maxDiff = None
+
     def _import_installer(self, path):
 
         errors = []
@@ -122,8 +124,8 @@ class ExtractionTests(unittest.TestCase):
                 'kind': 'standalone',
                 'sha256': '21ce4b6bf58db9b616f02792d18cc0fff854bca02fec0cc69faf7f9234ad03eb',
                 'uid': '21ce4b6bf58db9b616f02792d18cc0fff854bca02fec0cc69faf7f9234ad03eb',
-                'name':
-                'eMailIt',
+                'name': 'eMailIt',
+                'platform': 'epoc16',
                 'tags': ['opl', 'sibo', 'sis'],
                 'icons': [
                     {

--- a/tools/indexer.py
+++ b/tools/indexer.py
@@ -59,7 +59,7 @@ verbose = '--verbose' in sys.argv[1:] or '-v' in sys.argv[1:]
 logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO, format="[%(levelname)s] %(message)s")
 
 
-INDEXER_VERSION = 10
+INDEXER_VERSION = 11
 
 # TODO: Check if there are more languages.
 LANGUAGE_ORDER = ["en_GB", "en_US", "en_AU", "fr_FR", "de_DE", "it_IT", "nl_NL", "bg_BG", ""]
@@ -85,23 +85,6 @@ class Chdir(object):
 
     def __exit__(self, exc_type, exc_value, traceback):
         os.chdir(self.pwd)
-
-
-class Summary(object):
-
-    def __init__(self, installer_count, uid_count, version_count, sha_count):
-        self.installer_count = installer_count
-        self.uid_count = uid_count
-        self.version_count = version_count
-        self.sha_count = sha_count
-
-    def as_dict(self):
-        return {
-            'installerCount': self.installer_count,
-            'uidCount': self.uid_count,
-            'versionCount': self.version_count,
-            'shaCount': self.sha_count,
-        }
 
 
 class Version(object):
@@ -186,7 +169,18 @@ class Program(object):
 class Release(object):
 
     # TODO: Make the UID optional and don't attempt to synthesize other identifiers at this stage.
-    def __init__(self, filename, size, reference, kind, identifier, sha256, name, version, icons, tags):
+    def __init__(self,
+                 filename,
+                 size,
+                 reference,
+                 kind,
+                 identifier,
+                 sha256,
+                 name,
+                 version,
+                 icons,
+                 tags,
+                 platform):
         self.filename = filename
         self.size = size
         self.reference = reference
@@ -197,6 +191,7 @@ class Release(object):
         self.version = version
         self.icons = icons
         self.tags = tags
+        self.platform = platform
 
     def as_dict(self, relative_icons_path):
         dict = {
@@ -208,6 +203,7 @@ class Release(object):
             'uid': self.uid,
             'name': self.name,
             'tags': sorted(list(self.tags)),
+            'platform': self.platform,
         }
         if self.version is not None:
             dict['version'] = self.version
@@ -339,7 +335,8 @@ def import_installer(source, output_directory, reference, path, error_handler):
                    name=select_name(info["name"]),
                    version=info["version"],
                    icons=icons,
-                   tags=tags)
+                   tags=tags,
+                   platform="epoc32")
 
 
 def import_application(source, output_directory, reference, path, error_handler):
@@ -361,6 +358,13 @@ def import_application(source, output_directory, reference, path, error_handler)
     app_name = name
     has_aif = False
 
+    # Recognize the app to determine what to do.
+    details = opolua.recognize(path)
+    if details['type'] == 'unknown':
+        raise UnknownApplication()
+
+    platform = "epoc16" if details["era"] == "sibo" else "epoc32"
+
     if aif_path:
         try:
             info = opolua.dumpaif(aif_path)
@@ -372,8 +376,8 @@ def import_application(source, output_directory, reference, path, error_handler)
             error_handler(aif_path, e)
             logging.warning("Failed to parse AIF with message '%s'", e)
 
-    if not has_aif:
-        # TODO: Is this a valid test?
+    # If we don't have a manifest, we can attempt to load one from EPOC16-era OPAs.
+    if not has_aif and details['era'] == 'sibo' and details['type'] == 'opa':
         info = opolua.dumpaif(path)
         icons = opolua.get_icons(path)
         app_name = select_name(info["captions"])
@@ -389,7 +393,12 @@ def import_application(source, output_directory, reference, path, error_handler)
                    name=app_name,
                    version=None,
                    icons=icons,
-                   tags=tags)
+                   tags=tags,
+                   platform=platform)
+
+
+class UnknownApplication(Exception):
+    pass
 
 
 def import_source(source, output_directory, error_handler=None):
@@ -414,9 +423,13 @@ def import_source(source, output_directory, error_handler=None):
                                             reference=reference,
                                             path=file_path,
                                             error_handler=error_handler))
+        except (UnknownApplication, opolua.UnsupportedInstaller):
+            # It's safe to ignore these exceptions as it implies the file is not an EPOC16 or EPOC32 file.
+            continue
         except Exception as e:
             logging.error("Failed to import with message '%s", e)
             error_handler(file_path, e)
+            raise
 
     return apps
 
@@ -561,20 +574,33 @@ def group(library):
     total_count = 0
     details = collections.defaultdict(list)
     groups = collections.defaultdict(list)
+    platforms = {}
 
     for release in releases:
         # Fix-up the version to match the current API expectations. Ultimately we will want to expose this to the API.
         release['version'] = utils.format_version(release['version']) if 'version' in release else 'Unknown'
+
+        # Count the number of platforms seen.
+        release_platform = release['platform']
+        if release_platform not in platforms:
+            platforms[release_platform] = 1
+        else:
+            platforms[release_platform] = platforms[release_platform] + 1
+        
         unique_uids.add(release['uid'])
         unique_versions.add((release['uid'], release['version']))
         unique_shas.add(release['sha256'])
         total_count = total_count + 1
         details[(release['uid'], release['sha256'], release['version'])].append(release)
         groups[(release['uid'])].append(release)
-    summary = Summary(installer_count=total_count,
-                      uid_count=len(unique_uids),
-                      version_count=len(unique_versions),
-                      sha_count=len(unique_shas))
+
+    summary = {
+        "installerCount": total_count,
+        "uidCount": len(unique_uids),
+        "versionCount": len(unique_versions),
+        "shaCount": len(unique_shas),
+        "platforms": platforms,
+    }
 
     # Generate the library by grouping the programs together by identifier/uid.
     # This relies heavily on automatic grouping in the `Program` constructor which we may wish to make more explicit in
@@ -619,7 +645,7 @@ def group(library):
     # Write the summary.
     logging.info("Writing summary to '%s'...", summary_path)
     with open(summary_path, "w") as fh:
-        json.dump(summary.as_dict(), fh)
+        json.dump(summary, fh)
 
     # Write the sources.
     logging.info("Writing sources to '%s'...", sources_path)

--- a/tools/indexer.py
+++ b/tools/indexer.py
@@ -62,7 +62,7 @@ logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO, format="[%
 INDEXER_VERSION = 11
 
 # TODO: Check if there are more languages.
-LANGUAGE_ORDER = ["en_GB", "en_US", "en_AU", "fr_FR", "de_DE", "it_IT", "nl_NL", "bg_BG", ""]
+LANGUAGE_ORDER = ["en_GB", "en_US", "en_AU", "fr_FR", "de_DE", "it_IT", "nl_NL", "bg_BG", "is_IS", "cs_CZ", "sv_SE", "fr_CH", "fr_BE", "no_NO", ""]
 
 
 class MissingName(Exception):
@@ -363,9 +363,14 @@ def import_application(source, output_directory, reference, path, error_handler)
     if details['type'] == 'unknown':
         raise UnknownApplication()
 
+    # Perhaps we're incorrectly detecting MBM files?
+    if details["type"] == "mbm" or details["type"] == "resource":
+        raise UnknownApplication()
+
     platform = "epoc16" if details["era"] == "sibo" else "epoc32"
 
     if aif_path:
+        # TODO: Remove this check.
         try:
             info = opolua.dumpaif(aif_path)
             uid = ("0x%08x" % info["uid3"]).lower()

--- a/tools/opolua.py
+++ b/tools/opolua.py
@@ -42,6 +42,7 @@ RECOGNIZE_PATH = os.path.join(OPOLUA_DIRECTORY, "src", "recognize.lua")
 
 UNSUPPORTED_MESSAGE = "Only ER5 SIS files are supported"
 NOT_AN_AI_MESSAGE = "Not an AIF file"
+NO_DEVICE_MAPPING_MESSAGE = "No device path mapping for"
 
 try:
     LUA_PATH = os.environ["LUA_PATH"]
@@ -50,12 +51,23 @@ except KeyError:
     LUA_PATH = subprocess.check_output(["mise", "which", "lua", "--cd", OPOLUA_DIRECTORY]).decode("utf-8").strip()
 
 
-class InvalidInstaller(Exception):
+class UnsupportedInstaller(Exception):
     pass
 
 
 class InvalidAIF(Exception):
     pass
+
+
+class ExecutionError(Exception):
+
+    def __init__(self, stdout, stderr):
+        self.stdout = stdout
+        self.stderr = stderr
+
+    @property
+    def output(self):
+        return self.stdout + self.stderr
 
 
 class Image(object):
@@ -84,26 +96,28 @@ class Image(object):
         self._source.save(os.path.join(directory_path, self.filename), format="GIF")
 
 
-def run_json_command(command, path):
-    result = subprocess.run([LUA_PATH, command, "--json", path], capture_output=True)
-    stdout = result.stdout.decode('utf-8')
-    stderr = result.stderr.decode('utf-8')
-
-    if UNSUPPORTED_MESSAGE in stdout + stderr:
-        raise InvalidInstaller(stdout + stderr)
-    elif NOT_AN_AI_MESSAGE in stdout + stderr:
-        raise InvalidAIF(stdout + stderr)
-
-    # Check the return code.
-    # It might be nicer to mark
+def run_lua_command(command, encoding):
+    result = subprocess.run([LUA_PATH] + command, capture_output=True)
+    stdout = result.stdout.decode(encoding)
+    stderr = result.stderr.decode(encoding)
     try:
         result.check_returncode()
     except:
-        print("stderr")
-        print(stderr)
-        print("stdout")
-        print(stdout)
-        raise
+        raise ExecutionError(stdout, stderr)
+    return stdout
+
+
+def run_json_command(command, path, encoding="utf-8"):
+    try:
+        stdout = run_lua_command([command, "--json", path], encoding="utf-8")
+    except ExecutionError as e:
+        if UNSUPPORTED_MESSAGE in e.output:
+            raise UnsupportedInstaller(e.output)
+        elif NOT_AN_AI_MESSAGE in e.output:
+            raise InvalidAIF(e.output)
+        else:
+            # Everything else is an error we'd like to know about.
+            raise
 
     return json.loads(stdout)
 
@@ -117,9 +131,15 @@ def dumpaif(path):
 
 
 def dumpsis_extract(source, destination):
-    # TODO: #147: Capture dumpsis stdout and stderr in the case of failures
-    #       https://github.com/inseven/psion-software-index/issues/147
-    subprocess.check_call([LUA_PATH, DUMPSIS_PATH, source, destination])
+    # TODO: #188: Remove guard against dumpsis invalid relative path extraction failures #18
+    #       https://github.com/inseven/psion-software-index/issues/1888
+    try:
+        return run_lua_command([DUMPSIS_PATH, source, destination], encoding='cp1252')
+    except ExecutionError as e:
+        if NO_DEVICE_MAPPING_MESSAGE in e.output:
+            raise UnsupportedInstaller(e.output)
+        else:
+            raise
 
 
 def get_icons(aif_path):


### PR DESCRIPTION
This includes a drive-by fix to the overlay manifest documentation and finer-grained error checking to make it harder to miss extraction failures.