### PR TITLE
fix: 📦 Add the program kinds (standalone, installer) to the program groups endpoint

### DIFF
--- a/schema/groups.schema.json
+++ b/schema/groups.schema.json
@@ -29,9 +29,13 @@
             "platforms": {
                 "type": "array",
                 "items": {"enum": ["epoc16", "epoc32"]}
+            },
+            "kinds": {
+                "type": "array",
+                "items": {"enum": ["installer", "standalone"]}
             }
         },
-        "required": ["id", "name", "platforms"],
+        "required": ["id", "name", "platforms", "kinds"],
         "additionalProperties": false
     }
 }

--- a/tools/indexer.py
+++ b/tools/indexer.py
@@ -658,6 +658,7 @@ def group(library):
             'id': program.id,
             'name': program.name,
             'platforms': [program.platform],
+            'kinds': [kind for kind in program.kinds],
         }
         if program.icon is not None:
             entry['icon'] = program.icon


### PR DESCRIPTION
This will allow clients to perform some high-level filtering (e.g., displaying only standalone intallers) without adding _too_ much bloat to this top-level listing. (Ultimately it may still be necessary to provide a lightweight DB for querying.)