### PR TITLE
fix: 🙅 Disallow reused UIDs

### DIFF
--- a/libraries/full.yaml
+++ b/libraries/full.yaml
@@ -4,6 +4,21 @@ intermediates_directory: ../_intermediates
 output_directory: ../site
 overlays:
 - ../overlays
+blocked_identifiers:
+- uid/0x3a433d50
+- uid/0x3a633b6e
+- uid/0x3b746e6e
+- uid/0x4f535345
+- uid/0x415f524f
+- uid/0x422e3b45
+- uid/0x00444d43
+- uid/0x783d4552
+- uid/0x45483d4e
+- uid/0x63675c32
+- uid/0x4558452e
+- uid/0x45544948
+- uid/0x53203420
+- uid/0x58454854
 sources:
 - https://archive.org/download/3-libjune-05/3LIBJUNE05.iso
 - https://archive.org/download/backups_202508/backups.zip

--- a/tools/common.py
+++ b/tools/common.py
@@ -93,6 +93,12 @@ class Library(object):
         for source in self.sources:
             source.sync()
 
+    @property
+    def blocked_identifiers(self):
+        if 'blocked_identifiers' not in self._configuration:
+            return []
+        return self._configuration['blocked_identifiers']
+
 
 class InternetArchiveSource(object):
 

--- a/tools/indexer.py
+++ b/tools/indexer.py
@@ -622,12 +622,6 @@ def group(library):
                 'bpp': icon['bpp'],
             }
 
-    # UIDs known to be reused across multiple applications.
-    UID_BLOCKLIST = set([
-        "0x415f524f",
-        "0x4558452e",
-    ])
-
     # Generate program groupings for every possible identifier to ensure there's always a landing page.
     program_groups_all = collections.defaultdict(list)
     for release in releases:
@@ -639,10 +633,11 @@ def group(library):
     # Group the programs by UID followed by hash.
     # This is used to generate the top-level listing and the standalone /programs API end-point.
     # We also generate the legacy redirects here to ensure old URLs aren't broken.
+    blocked_identifiers = set(library.blocked_identifiers)
     program_groups = collections.defaultdict(list)
     redirects = {}
     for release in releases:
-        if 'uid' in release and release['uid'] not in UID_BLOCKLIST:
+        if 'uid' in release and 'uid/' + release['uid'] not in blocked_identifiers:
             program_groups['uid/' + release['uid']].append(release)
             redirects['programs/' + release['uid']] = 'programs/uid/' + release['uid']
         else:


### PR DESCRIPTION
Unfortunately a number of UIDs were reused, especially for things like automatic updaters. This change introduces the concept of blocked identifiers to the library configuration file and stops them from being used for grouping.

The set of identifiers introduced to 'full.yaml' as part of this change are all updaters (identified by searching for the string 'kB') and 'explodes' 295 EPOC32 programs. 💥