### PR TITLE
fix(content): Set name for 'NEUON - PacMan'

### DIFF
--- a/overlays/uid_0x100053f0 NEUON PacMan/index.md
+++ b/overlays/uid_0x100053f0 NEUON PacMan/index.md
@@ -1,4 +1,5 @@
 ---
+name: NEUON - PacMan
 subtitle: PacMan clone
 category: games/arcade
 publishers:


### PR DESCRIPTION
This stops it automatically picking up the name from one of the 'small' versions.